### PR TITLE
Update extra version bounds to ^>= 1.7.0

### DIFF
--- a/hedgehog-golden.cabal
+++ b/hedgehog-golden.cabal
@@ -68,7 +68,7 @@ library
     , containers ^>=0.6.0.1
     , Diff ^>=0.3.4
     , directory ^>=1.3.3.0
-    , extra ^>= 1.6.0
+    , extra ^>= 1.7.0
     , hedgehog ^>= 1.0.2
     , text ^>=1.2.3.1
 


### PR DESCRIPTION
We'd like to use this package in a project, but the constraints on `extra` prevent us from doing so. Everything still seems to build fine when updating to `extra ^>= 1.7.0`.